### PR TITLE
Fix 13

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -3,9 +3,10 @@ class AdminController < ApplicationController
 
   def index
     return nil unless current_user
-    @last_month = Date.today.months_ago(1)
+    @last_month = Date.today.last_month
     @charts_title = "今月(#{@last_month.year}年#{@last_month.month}月)の結果"
-    @last_month_items = current_user.items.where(purchased_at: @last_month.all_month)
+    @last_month_items = current_user.items.where(purchased_at: ["#{@last_month} 00:00:00.000000000 JST +09:00".."#{@last_month.end_of_month} 23:59:59 +0900"])
+
     @categories = current_user.categories.published.order(order: 'asc')
     @categories_title_path = @categories.pluck(:title,:path)
     @items = @last_month_items.group(:category_path).sum(:price)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
+  helper_method :current_page, :current_limit
   # CATEGORIES = ['food', 'necessaries', 'hobbies', 'transportation', 'fashion', 'helth', 'universiity', 'utility', 'account']
   CATEGORIES = ['食費', '日用品', '交通費', '趣味・娯楽', '服・美容', '健康・医療', '大学・部費・教材', '水道・光熱費', '口座']
   CATEGORIES_COLORS = ["#f50057", "#ffc400", "#f44336", "#8bc34a", "#4caf50", "#00bcd4", "#2979ff", "#4caf50", "#dddddd"]
@@ -11,6 +12,14 @@ class ApplicationController < ActionController::Base
       output = @items.where(category: CATEGORIES.length-2).pluck(:purchased_at, :price)
       output.map{|x| ["#{x[0].year}/#{x[0].month}", x[1]]}
     end
+  end
+
+  def current_page
+    (params[:page].presence || 1).to_i
+  end
+
+  def current_limit( default=30 )
+    (params[:limit].presence || default).to_i
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,6 +43,7 @@ protect_from_forgery
   def update
     if params[:action] == 'update'
       params_date = Date.parse(item_params[:purchased_at])
+      p params_date
       flash[:alert] = '店舗名を指定してください' if item_params[:title].blank?
       flash[:alert] = '今日以前の日付を指定してください' if Date.today <= params_date
       current_user.items.find(params[:id]).update(

--- a/app/views/_chart.html.slim
+++ b/app/views/_chart.html.slim
@@ -9,7 +9,7 @@ javascript:
     }]
   };
   const polar_areaConfig = {
-    type: 'polarArea',
+    type: 'pie',
     data: polar_areaData,
     options: {
       responsive: true,

--- a/app/views/archive/index.html.slim
+++ b/app/views/archive/index.html.slim
@@ -1,6 +1,10 @@
 - if signed_in?
   = render 'sessions/signed'
 
+  / - base_count = @months.limit_value * (@months.current_page-1)
+  / - start_count = base_count + 1
+  / - end_count = base_count + @months.size
+
   div class='px-5 py-5'
     h2 class='fw-bold pb-1' 毎月の記録一覧
     - if @months.present?
@@ -11,9 +15,9 @@
             th scope='col' 件数
 
         tbody
-          - @months.map do |month|
+          - @months.map do |month, count|
             tr
-              td = link_to month[0], "#{archive_path}/#{month[0]}", class: 'text-decoration-none'
-              td = month[1]
+              td = link_to "#{month}", "#{archive_path}/#{month}", class: 'text-decoration-none'
+              td = count
     - else
       div 現在、予約枠は登録されていません

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,6 +3,7 @@ html[lang="ja"]
   head
     title
       | Hhab
+    meta[name="description" content="このアプリは、シンプルな家計簿Webアプリです。"]
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag

--- a/db/migrate/20220918141305_change_date_format_in_items.rb
+++ b/db/migrate/20220918141305_change_date_format_in_items.rb
@@ -1,0 +1,9 @@
+class ChangeDateFormatInItems < ActiveRecord::Migration[6.1]
+  def up
+    change_column :items, :purchased_at, :datetime
+  end
+
+  def down
+    change_column :items, :purchased_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_17_164316) do
+ActiveRecord::Schema.define(version: 2022_09_18_141305) do
 
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false, comment: "タイトル"


### PR DESCRIPTION
- chart.js の修正
- archive ページのデータ取得方法を修正
  items テーブルの purchased_at の範囲検索方法を修正
- サイトの meta description を追加(仮)

---
- パフォーマンスが以前は60ぐらいだったが90近くになってきたのでひとまずOKかな

  <img width="600" alt="Screen Shot 2022-09-19 at 1 03 58 AM" src="https://user-images.githubusercontent.com/51039761/190916642-4766b51a-f883-4fbd-a8bf-5849443337c6.png">
