### PR TITLE
Fix 28

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,4 +5,9 @@ module ApplicationHelper
     url =  { sort: column, direction: direction }
     link_to "#{title} #{sort_direction == 'asc' ? '↓' : '↑'}", "?direction=#{direction}&sort=#{column}#items_table", class: "text-primary text-decoration-none sort_header #{css_class}"
   end
+  
+  def mobile?
+      return true if request.user_agent =~ /Mobile/
+      false
+    end
 end

--- a/app/views/_chart.html.slim
+++ b/app/views/_chart.html.slim
@@ -20,7 +20,7 @@ javascript:
               display: true,
               centerPointLabels: true,
               font: {
-                size: 18
+                size: 15
               }
             }
           }
@@ -162,6 +162,7 @@ javascript:
           backgroundColor: '#ec9ea5',
         },]
         }
+
         lineChart.update()
       })
     }

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -7,15 +7,18 @@
       div class='py-2 text-center'
         canvas id='polar_area' style='max-height: 35rem'
       div class='py-2 text-center' style='font-size: 20px;'
-        canvas id='bar' style='max-height: 35rem'
+        canvas id='bar' height='#{mobile? ? 400 : 300}' style='max-height: 35rem'
       div class='py-2 text-center' style='font-size: 20px;'
-        canvas id='line' style='max-height: 35rem'
+        canvas id='line' height='#{mobile? ? 400 : 300}' style='max-height: 35rem'
         / = select_tag :range_months, options_for_select(@months_count), id: 'select_months_count', class: 'form-select w-25', style: 'display: initial;'
         / label for="select_months_count" class="form-label" Example range
-        div class='d-flex' style='justify-content: center;'
-          span class='px-2' 最大化
-          input type='range' class='form-range w-25' min='0' max='#{@months_diff}' step='1' id='select_months_count' style='margin-top: 4px;'
-          span class='px-2' 最小化
+        div class='d-block' style='justify-content: center;'
+          div class='d-flex' style='justify-content: space-around;'
+            div class='px-2' 最大化
+            div class='px-2' 最小化
+          div class='' style=''
+            input type='range' class='form-range w-100 px-3' min='0' max='#{@months_diff}' step='1' id='select_months_count' style='margin-top: 4px;'
+          
 
     = render '/chart'
   

--- a/app/views/archive/subindex.html.slim
+++ b/app/views/archive/subindex.html.slim
@@ -11,7 +11,7 @@
     div class='py-2 text-center'
       canvas id='polar_area' style='max-height: 35rem'
     div class='py-2 text-center' style='font-size: 20px;'
-      canvas id='bar' style='max-height: 35rem'
+      canvas id='bar' height='#{mobile? ? 400 : 300}' style='max-height: 35rem'
 
   = render '/chart'
 


### PR DESCRIPTION
- スマホだとbar chartの縦軸が低すぎて見にくい -> 高くする
- スマホだと年間収支のrangeボタンの横幅が小さすぎて見にくい -> 広くする
意外とpcでもinput range の幅が広い方が操作がしやすいのでfullWidthにした